### PR TITLE
chore: migrate to Rust 1.95.0 and template base image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 name = "threatflux-hashing"
 version = "0.1.8"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.95.0"
 authors = ["ThreatFlux"]
 description = "High-performance async file hashing library supporting MD5, SHA256, SHA512, and BLAKE3"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump project baseline to Rust 1.95.0.
- Update CI/tooling and Docker base image references to `docker.io/threatflux/rust-cicd-template:base-rust-latest` / `base-rust-1.95.0` patterns where applicable.
- Apply migration updates from `chore/rust-1.95-and-deps`.

This PR is part of the repository-wide ThreatFlux Rust toolchain migration.